### PR TITLE
Double quotes value support with backslashes-escaped for env files

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -65,7 +65,17 @@ fn parse_env_content(env_content: &str) -> IndexMap<String, String> {
 
             if env_part.len() == 2 {
                 let key = env_part[0].trim().to_string();
-                let value = env_part[1].trim().to_string();
+                let mut value = env_part[1].trim().to_string();
+
+                value = value
+                    .replace("\\\"", "\"")
+                    .replace("\\n", "\n")
+                    .replace("\\r", "\r");
+
+                if value.starts_with('"') && value.ends_with('"') {
+                    value.remove(0);
+                    value.pop();
+                }
 
                 env.insert(key, value);
             }

--- a/src/file_test.rs
+++ b/src/file_test.rs
@@ -12,6 +12,11 @@ fn load_file_valid() {
     assert_eq!(environment::get_or_panic("load1"), "value1");
     assert_eq!(environment::get_or_panic("load2"), "value2");
     assert_eq!(environment::get_or_panic("load3"), "==value3==");
+    assert_eq!(environment::get_or_panic("load4"), "value4");
+    assert_eq!(environment::get_or_panic("load5"), "value5");
+    assert_eq!(environment::get_or_panic("load6"), "==value\"6\"==");
+    assert_eq!(environment::get_or_panic("load7"), "value\"7\n");
+    assert_eq!(environment::get_or_panic("load8"), "value\r\"8");
 }
 
 #[test]

--- a/src/file_test.rs
+++ b/src/file_test.rs
@@ -17,6 +17,15 @@ fn load_file_valid() {
     assert_eq!(environment::get_or_panic("load6"), "==value\"6\"==");
     assert_eq!(environment::get_or_panic("load7"), "value\"7\n");
     assert_eq!(environment::get_or_panic("load8"), "value\r\"8");
+    assert_eq!(environment::get_or_panic("load9"), "\"value9");
+    assert_eq!(environment::get_or_panic("load10"), "value10\"");
+    assert_eq!(environment::get_or_panic("load11"), "\"value11\"");
+    assert_eq!(environment::get_or_panic("load12"), "\"");
+    assert_eq!(environment::get_or_panic("load13"), "\"\"");
+    assert_eq!(environment::get_or_panic("load14"), "\"value14");
+    assert_eq!(environment::get_or_panic("load15"), "value15\"");
+    assert_eq!(environment::get_or_panic("load16"), "");
+    assert_eq!(environment::get_or_panic("load17"), "");
 }
 
 #[test]

--- a/src/test/load.env
+++ b/src/test/load.env
@@ -2,5 +2,10 @@
 load1=value1
 load2 = value2
 load3 = ==value3==
+load4="value4"
+load5 = "value5"
+load6 = ==value"6"==
+load7 = "value\"7\n"
+load8 = "value\r\"8"
 
 # another comment line

--- a/src/test/load.env
+++ b/src/test/load.env
@@ -2,10 +2,21 @@
 load1=value1
 load2 = value2
 load3 = ==value3==
+
+# test comment line for "double quotes" wrappers
 load4="value4"
 load5 = "value5"
 load6 = ==value"6"==
 load7 = "value\"7\n"
 load8 = "value\r\"8"
+load9 = "\"value9"
+load10 = "value10\""
+load11 = "\"value11\""
+load12 = "\""
+load13 = "\"\""
+load14="value14
+load15=value15"
+load16="
+load17=\"
 
 # another comment line


### PR DESCRIPTION
This PR adds support for file environment variables that contain _double quotes_ wrappers (resolves #21). Additionally it scapes backslashes too.

