### PR TITLE
Add checkpoint system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ indexmap = "^1"
 
 [dev-dependencies]
 doc-comment = "^0.3"
-serial_test = "0.9.0"
 
 [badges.codecov]
 branch = "master"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ indexmap = "^1"
 
 [dev-dependencies]
 doc-comment = "^0.3"
+serial_test = "0.9.0"
 
 [badges.codecov]
 branch = "master"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,4 +7,5 @@ additional_profiles = [
   "ci-all-build-tasks",
   "ci-static-code-analysis-tasks",
   "publish-pre-cleanup",
+  "multi-phase-tests"
 ]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,79 @@
+use std::collections::{HashMap, HashSet};
+
+#[cfg(test)]
+#[path = "./checkpoint_test.rs"]
+mod checkpoint_test;
+
+/// Environment variable checkpoint
+///
+/// A checkpoint stores all environment variables present at the time it was initialized,
+/// which then can be restored using the [`restore`] method.
+///
+/// A checkpoint can be "impure", by excluding a set of variables, which should not be checkpointed,
+/// if not specified or added this will reset **every** value.
+pub struct Checkpoint {
+    snapshot: HashMap<String, String>,
+    exclude: HashSet<String>,
+}
+
+impl Checkpoint {
+    /// Create a new Checkpoint
+    ///
+    /// This captures all currently present environment variables.
+    pub fn new() -> Self {
+        let mut env = HashMap::new();
+        env.extend(crate::environment::vars());
+
+        Self {
+            snapshot: env,
+            exclude: HashSet::new(),
+        }
+    }
+
+    /// Exclude a key from the [`Checkpoint::restore`]
+    ///
+    /// Keys that have been excluded will not be removed, created or modified in the restore process.
+    pub fn exclude<T: Into<String>>(&mut self, key: T) {
+        self.exclude.insert(key.into());
+    }
+
+    /// Restore the current state of environment to the state the checkpoint was taken in.
+    ///
+    /// This will remove added keys, re-create values and set new values.
+    /// This will skip setting unchanged values.
+    pub fn restore(self) {
+        let chk = self.snapshot;
+
+        let mut env = HashMap::new();
+        env.extend(crate::environment::vars());
+
+        let exclude: HashSet<_> = self.exclude.iter().collect();
+
+        // only change the variables that are of significance, this means we need to partition into
+        // 3 piles:
+        //  * to be removed
+        //  * to be added
+        //  * to be changed
+
+        let chk_keys = &chk.keys().collect::<HashSet<_>>() - &exclude;
+        let env_keys = &env.keys().collect::<HashSet<_>>() - &exclude;
+
+        let remove = &env_keys - &chk_keys;
+        let create = &chk_keys - &env_keys;
+
+        let modify = (&chk_keys & &env_keys)
+            .into_iter()
+            .filter(|key| &chk[*key] != &env[*key])
+            .collect::<HashSet<_>>();
+
+        println!("REMOVE: {remove:?}, CREATE: {create:?}, MODIFY: {modify:?}");
+
+        for key in remove {
+            crate::environment::remove(key);
+        }
+
+        for key in &create | &modify {
+            crate::environment::set(key, &chk[key]);
+        }
+    }
+}

--- a/src/checkpoint_test.rs
+++ b/src/checkpoint_test.rs
@@ -1,0 +1,108 @@
+use crate::Checkpoint;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn create() {
+    crate::remove("VAR");
+
+    crate::set("VAR", "1");
+
+    let chk = Checkpoint::new();
+
+    crate::remove("VAR");
+
+    chk.restore();
+
+    assert!(crate::is_equal("VAR", "1"));
+}
+
+#[test]
+#[serial]
+fn create_exclude() {
+    crate::remove("VAR1");
+    crate::remove("VAR2");
+
+    crate::set("VAR1", "1");
+    crate::set("VAR2", "2");
+
+    let mut chk = Checkpoint::new();
+    chk.exclude("VAR1");
+
+    crate::remove("VAR1");
+    crate::remove("VAR2");
+
+    chk.restore();
+
+    assert!(!crate::exists("VAR1"));
+    assert_eq!(crate::get_or_panic("VAR2"), "2".to_owned())
+}
+
+#[test]
+#[serial]
+fn remove() {
+    crate::remove("VAR");
+
+    let chk = Checkpoint::new();
+
+    crate::set("VAR", "1");
+
+    chk.restore();
+
+    assert!(!crate::exists("VAR"));
+}
+
+#[test]
+#[serial]
+fn remove_exclude() {
+    crate::remove("VAR1");
+    crate::remove("VAR2");
+
+    let mut chk = Checkpoint::new();
+    chk.exclude("VAR1");
+
+    crate::set("VAR1", "1");
+    crate::set("VAR2", "2");
+
+    chk.restore();
+
+    assert_eq!(crate::get_or_panic("VAR1"), "1".to_owned());
+    assert!(!crate::exists("VAR2"));
+}
+
+#[test]
+#[serial]
+fn modify() {
+    crate::remove("VAR");
+
+    crate::set("VAR", "1");
+
+    let chk = Checkpoint::new();
+
+    crate::set("VAR", "2");
+
+    chk.restore();
+
+    assert_eq!(crate::get_or_panic("VAR"), "1".to_owned())
+}
+
+#[test]
+#[serial]
+fn modify_exclude() {
+    crate::remove("VAR1");
+    crate::remove("VAR2");
+
+    crate::set("VAR1", "1");
+    crate::set("VAR2", "2");
+
+    let mut chk = Checkpoint::new();
+    chk.exclude("VAR1");
+
+    crate::set("VAR1", "3");
+    crate::set("VAR2", "4");
+
+    chk.restore();
+
+    assert_eq!(crate::get_or_panic("VAR1"), "3".to_owned());
+    assert_eq!(crate::get_or_panic("VAR2"), "2".to_owned())
+}

--- a/src/checkpoint_test.rs
+++ b/src/checkpoint_test.rs
@@ -1,8 +1,7 @@
 use crate::Checkpoint;
-use serial_test::serial;
 
 #[test]
-#[serial]
+#[ignore]
 fn create() {
     crate::remove("VAR");
 
@@ -18,7 +17,7 @@ fn create() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn create_exclude() {
     crate::remove("VAR1");
     crate::remove("VAR2");
@@ -39,7 +38,7 @@ fn create_exclude() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn remove() {
     crate::remove("VAR");
 
@@ -53,7 +52,7 @@ fn remove() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn remove_exclude() {
     crate::remove("VAR1");
     crate::remove("VAR2");
@@ -71,7 +70,7 @@ fn remove_exclude() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn modify() {
     crate::remove("VAR");
 
@@ -87,7 +86,7 @@ fn modify() {
 }
 
 #[test]
-#[serial]
+#[ignore]
 fn modify_exclude() {
     crate::remove("VAR1");
     crate::remove("VAR2");


### PR DESCRIPTION
Add a minimalistic checkpoint system to `envmnt`, which is used to quickly restore the environment when needed.
This also supports exclusions for checkpoints that want to keep specific variables even when restoring.


```rust
let chk = envmnt::checkpoint();

// create and remove env variables

// task finished, so roll back
chk.restore()
```